### PR TITLE
[front/feat/#24] 페이지 이동/AI 변환 버튼 구현

### DIFF
--- a/frontend/src/components/LeftAIShift.jsx
+++ b/frontend/src/components/LeftAIShift.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+function LeftAIShift() {
+  return (
+    <LeftContainer>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 76">
+        <line
+          y1="-5"
+          x2="56.6392"
+          y2="-5"
+          transform="matrix(-0.741536 0.670913 -0.960966 -0.276668 42 0)"
+          stroke="#3F3D3F"
+          strokeWidth="10"
+        />
+        <line
+          y1="-5"
+          x2="56.6392"
+          y2="-5"
+          transform="matrix(-0.741536 -0.670913 -0.960966 0.276668 42 76)"
+          stroke="#3F3D3F"
+          strokeWidth="10"
+        />
+      </svg>
+    </LeftContainer>
+  );
+}
+
+export default LeftAIShift;
+
+const LeftContainer = styled.div`
+  width: 42px;
+  height: 76px;
+  flex-shrink: 0;
+  cursor: pointer;
+`;

--- a/frontend/src/components/PageShiftBtn.jsx
+++ b/frontend/src/components/PageShiftBtn.jsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+
+function PageShiftBtn() {
+  return (
+    <PageContainer>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 77 77" fill="none">
+        <g filter="url(#filter0_d_606_413)">
+          <circle cx="38.5" cy="34.5" r="33" stroke="#151515" strokeWidth="3" />
+          <path d="M31 20L46 34.5L31 49" stroke="#151515" strokeWidth="3" />
+        </g>
+        <defs>
+          <filter
+            id="filter0_d_606_413"
+            x="0"
+            y="0"
+            width="77"
+            height="77"
+            filterUnits="userSpaceOnUse"
+            colorInterpolationFilters="sRGB"
+          >
+            <feFlood floodOpacity="0" result="BackgroundImageFix" />
+            <feColorMatrix
+              in="SourceAlpha"
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+              result="hardAlpha"
+            />
+            <feOffset dy="4" />
+            <feGaussianBlur stdDeviation="2" />
+            <feComposite in2="hardAlpha" operator="out" />
+            <feColorMatrix
+              type="matrix"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"
+            />
+            <feBlend
+              mode="normal"
+              in2="BackgroundImageFix"
+              result="effect1_dropShadow_606_413"
+            />
+            <feBlend
+              mode="normal"
+              in="SourceGraphic"
+              in2="effect1_dropShadow_606_413"
+              result="shape"
+            />
+          </filter>
+        </defs>
+      </svg>
+    </PageContainer>
+  );
+}
+
+export default PageShiftBtn;
+
+const PageContainer = styled.div`
+  width: 69px;
+  height: 69px;
+  flex-shrink: 0;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+  cursor: pointer;
+`;

--- a/frontend/src/components/RightAIShift.jsx
+++ b/frontend/src/components/RightAIShift.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+function RightAIShift() {
+  return (
+    <RightContainer>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 76">
+        <line
+          y1="-5"
+          x2="56.6392"
+          y2="-5"
+          transform="matrix(0.741536 0.670913 0.960966 -0.276668 10 0)"
+          stroke="#3F3D3F"
+          strokeWidth="10"
+        />
+        <line
+          y1="-5"
+          x2="56.6392"
+          y2="-5"
+          transform="matrix(0.741536 -0.670913 0.960966 0.276668 10 76)"
+          stroke="#3F3D3F"
+          strokeWidth="10"
+        />
+      </svg>
+    </RightContainer>
+  );
+}
+
+export default RightAIShift;
+
+const RightContainer = styled.div`
+  width: 42px;
+  height: 76px;
+  flex-shrink: 0;
+  cursor: pointer;
+`;


### PR DESCRIPTION
개요 : 페이지 이동과 AI 변환 버튼을 구현

설명 :
- PageShiftBtn.jsx
- RightAIShift.jsx
- LeftAIShift.jsx
- 이미지 업로드 페이지부터 다음 페이지로 이동하고 싶을 때와 내가 원하는 AI를 볼려고 넘길 때 사용하는 버튼을 구현

결과 :
<img width="91" alt="스크린샷 2023-07-12 오후 11 40 23" src="https://github.com/2023SB-TeamJ/2023SB-Team-J/assets/127868094/97f367e1-7e97-4430-b982-b3853958bbe2">
